### PR TITLE
shorten assignment of -1 to list/board

### DIFF
--- a/dfs.py
+++ b/dfs.py
@@ -10,22 +10,8 @@ maximum_depth = 0
 count = 0
 
 board = [[1 for j in range(7)] for i in range(7)]
-board[0][0] = -1
-board[0][1] = -1
-board[1][0] = -1
-board[1][1] = -1
-board[5][0] = -1
-board[5][1] = -1
-board[6][0] = -1
-board[6][1] = -1
-board[0][5] = -1
-board[0][6] = -1
-board[1][5] = -1
-board[1][6] = -1
-board[5][5] = -1
-board[5][6] = -1
-board[6][5] = -1
-board[6][6] = -1
+for j, i in [(j, i) for j in [i for i in range(7) if i%5 in [0, 1]] for i in range(7) if i%5 in [0, 1]]:
+    board[j][i] = -1
 board[3][3] = 0
 
 


### PR DESCRIPTION
I realized that the positions where -1 was going are multiples of 5 (0 and 5) and multiples of 6 (0 and 6), so what I did was relate them to produce a list with the positions producing a list like this: [ ( 0, 0), (0, 1) , (0, 5), (0, 6), (1, 0), (1, 1), (1, 5), (1, 6), (5 , 0), (5, 1), ( 5, 5), (5, 6), (6, 0), (6, 1), (6, 5), (6, 6)], then play it back with a loop to assign -1 to each position in the corresponding list.

It's a somewhat "complex" solution but the code is shorter, although it's a bit harder to read if you don't know the description and its function. So I don't know if it is the most efficient.